### PR TITLE
Icow-service now uses secrets to store accesskey and secretkey for s3.

### DIFF
--- a/deployment/icow/templates/inference-knative-service.yaml
+++ b/deployment/icow/templates/inference-knative-service.yaml
@@ -18,9 +18,15 @@ spec:
           name: h2c
         env:
         - name: AWS_ACCESS_KEY
-          value: {{ .Values.s3.access_key }}
+          valueFrom:
+            secretKeyRef:
+              name: icow-s3-access
+              key: accesskey
         - name: AWS_SECRET_KEY
-          value: {{ .Values.s3.secret_key }}
+          valueFrom:
+            secretKeyRef:
+              name: icow-s3-access
+              key: secretkey
         - name: S3ENDPOINT_URL
           value: {{ .Values.s3.endpoint }}
         {{- if .Values.resources }}

--- a/deployment/icow/templates/secrets.yaml
+++ b/deployment/icow/templates/secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: icow-s3-access
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  accesskey: {{ .Values.s3.access_key | toString | b64enc | quote }}
+  secretkey: {{ .Values.s3.secret_key | toString | b64enc | quote }}


### PR DESCRIPTION
Helm chart has been updated to store s3 access key and secret key as k8s secrets.